### PR TITLE
Turn the key tweaks

### DIFF
--- a/Assets/Scripts/ComponentSolvers/Modded/Perky/TurnTheKeyAdvancedComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Modded/Perky/TurnTheKeyAdvancedComponentSolver.cs
@@ -42,6 +42,7 @@ public class TurnTheKeyAdvancedComponentSolver : ComponentSolver
             {
                 int modules = bombInfo.GetSolvedModuleNames().Count(x => RightAfterA.Contains(x) || LeftAfterA.Contains(x));
                 TwitchPlaySettings.AddRewardBonus(2 * modules);
+                IRCConnection.SendMessage("Reward increased by {0} for defusing module !{1} ({2}).", modules * 2, Code, bombModule.ModuleDisplayName);
             }
         }
         return false;

--- a/Assets/Scripts/ComponentSolvers/Modded/Perky/TurnTheKeyAdvancedComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Modded/Perky/TurnTheKeyAdvancedComponentSolver.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Linq;
 using System.Reflection;
 using UnityEngine;
 
@@ -11,6 +12,48 @@ public class TurnTheKeyAdvancedComponentSolver : ComponentSolver
         _leftKey = (MonoBehaviour)_leftKeyField.GetValue(bombComponent.GetComponent(_componentType));
         _rightKey = (MonoBehaviour)_rightKeyField.GetValue(bombComponent.GetComponent(_componentType));
         modInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType());
+
+        ((KMSelectable) _leftKey).OnInteract = HandleLeftKey;
+        ((KMSelectable) _rightKey).OnInteract = HandleRightKey;
+    }
+
+    private bool HandleRightKey()
+    {
+        if (!GetValue(_activatedField) || GetValue(_rightKeyTurnedField)) return false;
+        KMBombInfo bombInfo = BombComponent.GetComponent<KMBombInfo>();
+        KMBombModule bombModule = BombComponent.GetComponent<KMBombModule>();
+
+        _beforeRightKeyField.SetValue(null, TwitchPlaySettings.data.DisableTurnTheKeysSoftLock ? new string[0] : RightBeforeA);
+        _onRightKeyTurnMethod.Invoke(BombComponent.GetComponent(_componentType), null);
+        if (GetValue(_rightKeyTurnedField) && TwitchPlaySettings.data.DisableTurnTheKeysSoftLock)
+        {
+            //Check to see if any forbidden modules for this key were solved.
+            if (bombInfo.GetSolvedModuleNames().Any(x => RightBeforeA.Contains(x)))
+                bombModule.HandleStrike();  //If so, Award a strike for it.
+        }
+        return false;
+    }
+
+    private bool HandleLeftKey()
+    {
+        if (!GetValue(_activatedField) || GetValue(_leftKeyTurnedField)) return false;
+        KMBombInfo bombInfo = BombComponent.GetComponent<KMBombInfo>();
+        KMBombModule bombModule = BombComponent.GetComponent<KMBombModule>();
+
+        _beforeLeftKeyField.SetValue(null, TwitchPlaySettings.data.DisableTurnTheKeysSoftLock ? new string[0] : LeftBeforeA);
+        _onLeftKeyTurnMethod.Invoke(BombComponent.GetComponent(_componentType), null);
+        if (GetValue(_leftKeyTurnedField) && TwitchPlaySettings.data.DisableTurnTheKeysSoftLock)
+        {
+            //Check to see if any forbidden modules for this key were solved.
+            if (bombInfo.GetSolvedModuleNames().Any(x => LeftBeforeA.Contains(x)))
+                bombModule.HandleStrike();  //If so, Award a strike for it.
+        }
+        return false;
+    }
+
+    private bool GetValue(FieldInfo field)
+    {
+        return (bool) field.GetValue(BombComponent.GetComponent(_componentType));
     }
 
     protected override IEnumerator RespondToCommandInternal(string inputCommand)
@@ -41,12 +84,45 @@ public class TurnTheKeyAdvancedComponentSolver : ComponentSolver
         _componentType = ReflectionHelper.FindType("TurnKeyAdvancedModule");
         _leftKeyField = _componentType.GetField("LeftKey", BindingFlags.Public | BindingFlags.Instance);
         _rightKeyField = _componentType.GetField("RightKey", BindingFlags.Public | BindingFlags.Instance);
+        _activatedField = _componentType.GetField("bActivated", BindingFlags.NonPublic | BindingFlags.Instance);
+        _beforeLeftKeyField = _componentType.GetField("LeftBeforeA", BindingFlags.NonPublic | BindingFlags.Static);
+        _beforeRightKeyField = _componentType.GetField("RightBeforeA", BindingFlags.NonPublic | BindingFlags.Static);
+        _leftKeyTurnedField = _componentType.GetField("bLeftKeyTurned", BindingFlags.NonPublic | BindingFlags.Instance);
+        _rightKeyTurnedField = _componentType.GetField("bRightKeyTurned", BindingFlags.NonPublic | BindingFlags.Instance);
+        _onLeftKeyTurnMethod = _componentType.GetMethod("OnLeftKeyTurn", BindingFlags.NonPublic | BindingFlags.Instance);
+        _onRightKeyTurnMethod = _componentType.GetMethod("OnRightKeyTurn", BindingFlags.NonPublic | BindingFlags.Instance);
     }
 
     private static Type _componentType = null;
     private static FieldInfo _leftKeyField = null;
     private static FieldInfo _rightKeyField = null;
+    private static FieldInfo _activatedField = null;
+    private static FieldInfo _beforeLeftKeyField = null;
+    private static FieldInfo _beforeRightKeyField = null;
+    private static FieldInfo _leftKeyTurnedField = null;
+    private static FieldInfo _rightKeyTurnedField = null;
+    private static MethodInfo _onLeftKeyTurnMethod = null;
+    private static MethodInfo _onRightKeyTurnMethod = null;
 
     private MonoBehaviour _leftKey = null;
     private MonoBehaviour _rightKey = null;
+
+    private static string[] LeftBeforeA = new string[]
+    {
+        "Maze",
+        "Memory",
+        "Complicated Wires",
+        "Wire Sequence",
+        "Cryptography"
+    };
+
+    private static string[] RightBeforeA = new string[]
+    {
+        "Semaphore",
+        "Combination Lock",
+        "Simon Says",
+        "Astrology",
+        "Switches",
+        "Plumbing"
+    };
 }

--- a/Assets/Scripts/ComponentSolvers/Modded/Perky/TurnTheKeyAdvancedComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Modded/Perky/TurnTheKeyAdvancedComponentSolver.cs
@@ -23,6 +23,13 @@ public class TurnTheKeyAdvancedComponentSolver : ComponentSolver
         KMBombInfo bombInfo = BombComponent.GetComponent<KMBombInfo>();
         KMBombModule bombModule = BombComponent.GetComponent<KMBombModule>();
 
+        if (TwitchPlaySettings.data.EnforceSolveAllBeforeTurningKeys &&
+            RightAfterA.Any(x => bombInfo.GetSolvedModuleNames().Count(x.Equals) != bombInfo.GetSolvableModuleNames().Count(x.Equals)))
+        {
+            bombModule.HandleStrike();
+            return false;
+        }
+
         _beforeRightKeyField.SetValue(null, TwitchPlaySettings.data.DisableTurnTheKeysSoftLock ? new string[0] : RightBeforeA);
         _onRightKeyTurnMethod.Invoke(BombComponent.GetComponent(_componentType), null);
         if (GetValue(_rightKeyTurnedField) && TwitchPlaySettings.data.DisableTurnTheKeysSoftLock)
@@ -39,6 +46,13 @@ public class TurnTheKeyAdvancedComponentSolver : ComponentSolver
         if (!GetValue(_activatedField) || GetValue(_leftKeyTurnedField)) return false;
         KMBombInfo bombInfo = BombComponent.GetComponent<KMBombInfo>();
         KMBombModule bombModule = BombComponent.GetComponent<KMBombModule>();
+
+        if (TwitchPlaySettings.data.EnforceSolveAllBeforeTurningKeys &&
+            LeftAfterA.Any(x => bombInfo.GetSolvedModuleNames().Count(x.Equals) != bombInfo.GetSolvableModuleNames().Count(x.Equals)))
+        {
+            bombModule.HandleStrike();
+            return false;
+        }
 
         _beforeLeftKeyField.SetValue(null, TwitchPlaySettings.data.DisableTurnTheKeysSoftLock ? new string[0] : LeftBeforeA);
         _onLeftKeyTurnMethod.Invoke(BombComponent.GetComponent(_componentType), null);
@@ -107,6 +121,16 @@ public class TurnTheKeyAdvancedComponentSolver : ComponentSolver
     private MonoBehaviour _leftKey = null;
     private MonoBehaviour _rightKey = null;
 
+    private static string[] LeftAfterA = new string[]
+    {
+        "Password",
+        "Crazy Talk",
+        "Who's On First",
+        "Keypads",
+        "Listening",
+        "Orientation"
+    };
+
     private static string[] LeftBeforeA = new string[]
     {
         "Maze",
@@ -114,6 +138,16 @@ public class TurnTheKeyAdvancedComponentSolver : ComponentSolver
         "Complicated Wires",
         "Wire Sequence",
         "Cryptography"
+    };
+
+    private static string[] RightAfterA = new string[]
+    {
+        "Morse Code",
+        "Wires",
+        "Two Bits",
+        "The Button",
+        "Colour Flash",
+        "Round Keypad"
     };
 
     private static string[] RightBeforeA = new string[]

--- a/Assets/Scripts/ComponentSolvers/Modded/Perky/TurnTheKeyComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Modded/Perky/TurnTheKeyComponentSolver.cs
@@ -9,8 +9,44 @@ public class TurnTheKeyComponentSolver : ComponentSolver
     public TurnTheKeyComponentSolver(BombCommander bombCommander, MonoBehaviour bombComponent, IRCConnection ircConnection, CoroutineCanceller canceller) :
         base(bombCommander, bombComponent, ircConnection, canceller)
     {
-        _lock = (MonoBehaviour)_lockField.GetValue(bombComponent.GetComponent(_componentType));
+        _lock = (MonoBehaviour)_lockField.GetValue(BombComponent.GetComponent(_componentType));
         modInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType());
+        BombCommander.twitchBombHandle.StartCoroutine(ReWriteTurnTheKey());
+    }
+
+    private bool OnKeyTurn()
+    {
+        _onKeyTurnMethod.Invoke(BombComponent.GetComponent(_componentType), null);
+        if (TwitchPlaySettings.data.AllowTurnTheKeyEarlyLate && !(bool)_solvedField.GetValue(BombComponent.GetComponent(_componentType)))
+        {
+            int time = (int)_targetTimeField.GetValue(BombComponent.GetComponent(_componentType));
+            float currentBombTime = BombCommander.CurrentTimer;
+            CommonReflectedTypeInfo.TimeRemainingField.SetValue(BombCommander.timerComponent, time + 0.5f);
+            _onKeyTurnMethod.Invoke(BombComponent.GetComponent(_componentType), null);
+            CommonReflectedTypeInfo.TimeRemainingField.SetValue(BombCommander.timerComponent, currentBombTime);
+        }
+        return false;
+    }
+
+    private IEnumerator ReWriteTurnTheKey()
+    {
+        yield return new WaitUntil(() => (bool) _activatedField.GetValue(BombComponent.GetComponent(_componentType)));
+        yield return new WaitForSeconds(0.1f);
+        _stopAllCorotinesMethod.Invoke(BombComponent.GetComponent(_componentType), null);
+
+        ((KMSelectable)_lock).OnInteract = OnKeyTurn;
+        int expectedTime = (int)_targetTimeField.GetValue(BombComponent.GetComponent(_componentType));
+        while (true)
+        {
+            int time = Mathf.FloorToInt(BombCommander.CurrentTimer);
+            if (time < expectedTime &&
+                !(bool)_solvedField.GetValue(BombComponent.GetComponent(_componentType)) &&
+                !TwitchPlaySettings.data.AllowTurnTheKeyEarlyLate)
+            {
+                BombComponent.GetComponent<KMBombModule>().HandleStrike();
+            }
+            yield return new WaitForSeconds(2.0f);
+        }
     }
 
     protected override IEnumerator RespondToCommandInternal(string inputCommand)
@@ -93,10 +129,20 @@ public class TurnTheKeyComponentSolver : ComponentSolver
     {
         _componentType = ReflectionHelper.FindType("TurnKeyModule");
         _lockField = _componentType.GetField("Lock", BindingFlags.Public | BindingFlags.Instance);
+        _activatedField = _componentType.GetField("bActivated", BindingFlags.NonPublic | BindingFlags.Instance);
+        _solvedField = _componentType.GetField("bUnlocked", BindingFlags.NonPublic | BindingFlags.Instance);
+        _targetTimeField = _componentType.GetField("mTargetSecond", BindingFlags.NonPublic | BindingFlags.Instance);
+        _stopAllCorotinesMethod = _componentType.GetMethod("StopAllCoroutines", BindingFlags.Public | BindingFlags.Instance);
+        _onKeyTurnMethod = _componentType.GetMethod("OnKeyTurn", BindingFlags.NonPublic | BindingFlags.Instance);
     }
 
     private static Type _componentType = null;
     private static FieldInfo _lockField = null;
+    private static FieldInfo _activatedField = null;
+    private static FieldInfo _solvedField = null;
+    private static FieldInfo _targetTimeField = null;
+    private static MethodInfo _stopAllCorotinesMethod = null;
+    private static MethodInfo _onKeyTurnMethod = null;
 
     private MonoBehaviour _lock = null;
 }

--- a/Assets/Scripts/MessageResponders/BombMessageResponder.cs
+++ b/Assets/Scripts/MessageResponders/BombMessageResponder.cs
@@ -260,10 +260,9 @@ public class BombMessageResponder : MessageResponder
             else
             {
                 _currentBomb = 0;
-                int id = 0;
-                for (var i = bombs.Length - 1; i >= 0; i--)
+                for (int i = 0; i < bombs.Length; i++)
                 {
-                    SetBomb((MonoBehaviour) bombs[i], id++);
+                    SetBomb((MonoBehaviour) bombs[i], i);
                 }
 
                 if (bombs.Length == 2 && rand.NextDouble() < specialNameProbability)

--- a/Assets/Scripts/TwitchPlaySettings.cs
+++ b/Assets/Scripts/TwitchPlaySettings.cs
@@ -31,6 +31,7 @@ public class TwitchPlaySettingsData
 	public Color UnclaimedColor = new Color(0.39f, 0.25f, 0.64f);
     public bool AllowTurnTheKeyEarlyLate = true;
     public bool DisableTurnTheKeysSoftLock = true;
+    public bool EnforceSolveAllBeforeTurningKeys = true;
 
 	public Dictionary<string, string> CustomMissions = new Dictionary<string, string>();
 	public List<string> ProfileWhitelist = new List<string>();

--- a/Assets/Scripts/TwitchPlaySettings.cs
+++ b/Assets/Scripts/TwitchPlaySettings.cs
@@ -30,6 +30,7 @@ public class TwitchPlaySettingsData
 	public float UnsubmittablePenaltyPercent = 0.3f;
 	public Color UnclaimedColor = new Color(0.39f, 0.25f, 0.64f);
     public bool AllowTurnTheKeyEarlyLate = true;
+    public bool DisableTurnTheKeysSoftLock = true;
 
 	public Dictionary<string, string> CustomMissions = new Dictionary<string, string>();
 	public List<string> ProfileWhitelist = new List<string>();

--- a/Assets/Scripts/TwitchPlaySettings.cs
+++ b/Assets/Scripts/TwitchPlaySettings.cs
@@ -29,6 +29,7 @@ public class TwitchPlaySettingsData
 	public bool EnableTwitchPlayShims = true;
 	public float UnsubmittablePenaltyPercent = 0.3f;
 	public Color UnclaimedColor = new Color(0.39f, 0.25f, 0.64f);
+    public bool AllowTurnTheKeyEarlyLate = true;
 
 	public Dictionary<string, string> CustomMissions = new Dictionary<string, string>();
 	public List<string> ProfileWhitelist = new List<string>();


### PR DESCRIPTION
* Possible now to turn the key early or late to solve the module, but at the cost of a strike.
* Possible to turn the left/right keys even after solving a module that key forbids being solved, but at the cost of a strike
* Actually enforce the requirement to solve ALL the required modules, and not just one instance of a given module before you can turn the left/right keys.

(All 3 of these options can be enabled/disabled in settings.)

* Also re-ordered the !bomb ID assigning,  as Factory gameplay room effectively requires this.